### PR TITLE
Added basic linux docker file.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+## To build:
+# docker build --tag sandypi
+## To run (add --rm if you don't want to have a bunch of copies):
+# docker run --publish 5000:5000 sandypi
+
+FROM nikolaik/python-nodejs:latest
+
+RUN set -x \
+    && apt-get update \
+    && apt install -y libopenjp2-7 libtiff5 \
+    && rm -rf /var/lib/apt/lists/
+
+WORKDIR /sandypi
+
+ADD . /sandypi
+
+# Remove the sudo commands
+RUN set -x \
+    && sed -i "s/sudo //g" ./install.sh \
+    && chmod a+x ./install.sh
+
+RUN set -x \
+    && ./install.sh
+
+CMD ["python","./start.py"]


### PR DESCRIPTION
I was just playing around with this on my Linux desktop and I didn't want npm to mess up all the other npm stuff I have. So I made a dockerfile script and it seems to run. I haven't tried connecting USB to the table yet. I assume I will need a --dev tag when I do.

This also isn't the perfect choice for rasbian, since I did not base it on an arm image. I don't _think_ this will work on a pi without picking a different starting image.

It does run though. I was poking around, I uploaded a pattern, I was playing with the FAKE serial port... Neat stuff!

It sure is nice to run it on my normal laptop. The whole install takes about a minute.