### PR TITLE
Adding a button to update the software

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ dist
 *.pyc
 
 server/saves/saved_settings.json
+run_update.txt
 
 start.bat
 start.sh

--- a/frontend/src/sockets/sEmits.js
+++ b/frontend/src/sockets/sEmits.js
@@ -130,8 +130,19 @@ function queueStartRandom(){
 // ---- MANUAL CONTROL ----
 
 function controlEmergencyStop(){
-    socket.emit("control_emergency_stop")
+    socket.emit("control_emergency_stop");
 }
+
+// ----- UPDATES -----
+
+function softwareStartUpdate(){
+    socket.emit("software_run_update");
+}
+
+function softwareChangeBranch(branch){
+    socket.emit("software_change_branch", branch);
+}
+
 
 
 export {
@@ -159,5 +170,7 @@ export {
     queueStartRandom,
     settingsSave,
     settingsShutdownSystem,
-    settingsRebootSystem
+    settingsRebootSystem,
+    softwareChangeBranch,
+    softwareStartUpdate
 };

--- a/frontend/src/structure/tabs/settings/Settings.js
+++ b/frontend/src/structure/tabs/settings/Settings.js
@@ -13,6 +13,7 @@ import { settingsNow } from '../../../sockets/sCallbacks';
 import { settingsSave } from '../../../sockets/sEmits';
 import { cloneDict } from '../../../utils/dictUtils';
 import SettingField from './SettingField';
+import SoftwareVersion from './SoftwareVersion';
 
 const mapStateToProps = (state) => {
     return {
@@ -185,6 +186,11 @@ class Settings extends Component{
                     </Subsection>
                     {this.generateHWSettings()}
                 </Section>
+                <SectionGroup sectionTitle="Software info">
+                    <Container>
+                        <SoftwareVersion/>
+                    </Container>
+                </SectionGroup>
                 <Row className="pr-3 pl-2 mb-5">
                     <Col>
                         <IconButton

--- a/frontend/src/structure/tabs/settings/SoftwareVersion.js
+++ b/frontend/src/structure/tabs/settings/SoftwareVersion.js
@@ -4,13 +4,13 @@ import { Col, Container, Form, Modal, Row } from 'react-bootstrap';
 import { CloudArrowDown } from 'react-bootstrap-icons';
 
 import IconButton from '../../../components/IconButton';
-import { getCurrentBranch, getCurrentHash, isUpToDate } from './selector';
+import { getCurrentBranch, getCurrentHash, updateAvailable } from './selector';
 import { setTab } from '../Tabs.slice';
 import { softwareChangeBranch, softwareStartUpdate } from '../../../sockets/sEmits';
 
 const mapStateToProps = (state) => {
     return {
-        isUpToDate: isUpToDate(state),
+        updateAvailable: updateAvailable(state),
         currentHash: getCurrentHash(state),
         currentBranch: getCurrentBranch(state)
     }
@@ -36,12 +36,12 @@ class SoftwareVersion extends Component{
     }
 
     renderUpdateButton(){
-        if (this.isUpToDate){
-            return <p>You are up to date</p>
-        }else return <IconButton icon={CloudArrowDown}
-            onClick={() => this.setState({...this.state, showUpdateConfirmModal: true})}>
-            Update the software
-        </IconButton>
+        if (this.props.updateAvailable){
+            return <IconButton icon={CloudArrowDown}
+                onClick={() => this.setState({...this.state, showUpdateConfirmModal: true})}>
+                Update the software
+            </IconButton>
+        }else return <p className="center rounded text-dark bg-primary p-3">The software is up to date</p>
     }
 
     render(){

--- a/frontend/src/structure/tabs/settings/SoftwareVersion.js
+++ b/frontend/src/structure/tabs/settings/SoftwareVersion.js
@@ -50,6 +50,8 @@ class SoftwareVersion extends Component{
                 ATTENTION: the update button is just a shortcut to update without the need of the command line.
                 This feature is not optimized yet and the automatic update may not work. 
                 Use it only if you know what you are doing.
+                The update will take a while (up to 1h). 
+                If nothing happens after 1h probably something has gone wrong.
             </p>
             <p>
                 NOTE: the master branch is the most stable version of the software. 

--- a/frontend/src/structure/tabs/settings/SoftwareVersion.js
+++ b/frontend/src/structure/tabs/settings/SoftwareVersion.js
@@ -1,0 +1,146 @@
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { Col, Container, Form, Modal, Row } from 'react-bootstrap';
+import { CloudArrowDown } from 'react-bootstrap-icons';
+
+import IconButton from '../../../components/IconButton';
+import { getCurrentBranch, getCurrentHash, isUpToDate } from './selector';
+import { setTab } from '../Tabs.slice';
+import { softwareChangeBranch, softwareStartUpdate } from '../../../sockets/sEmits';
+
+const mapStateToProps = (state) => {
+    return {
+        isUpToDate: isUpToDate(state),
+        currentHash: getCurrentHash(state),
+        currentBranch: getCurrentBranch(state)
+    }
+}
+
+const mapDispatchToProps = (dispatch) => {
+    return {
+        goToHome: () => dispatch(setTab("home"))
+    }
+}
+
+const BRANCHES = ["Master", "Alpha", "Beta"];
+
+class SoftwareVersion extends Component{
+
+    constructor(props){
+        super(props);
+        this.state = {
+            showUpdateConfirmModal: false,
+            showBranchChangeModal: false,
+            newBranch: ""
+        }
+    }
+
+    renderUpdateButton(){
+        if (this.isUpToDate){
+            return <p>You are up to date</p>
+        }else return <IconButton icon={CloudArrowDown}
+            onClick={() => this.setState({...this.state, showUpdateConfirmModal: true})}>
+            Update the software
+        </IconButton>
+    }
+
+    render(){
+        return <Container>
+            <p className="text-danger">
+                ATTENTION: the update button is just a shortcut to update without the need of the command line.
+                This feature is not optimized yet and the automatic update may not work. 
+                Use it only if you know what you are doing.
+            </p>
+            <p>
+                NOTE: the master branch is the most stable version of the software. 
+                The beta branch is a pre-release branch and we try to fix all the bugs there before merging to the master branch.
+                The alpha brings all the latest features but it is for sure full of bugs (not suited for the everyday usage probably)
+            </p>
+            <Row>
+                <Col sm={4}>
+                    Current version: <p className={"text-light"}>{this.props.currentBranch +" - " + this.props.currentHash}</p>
+                </Col>
+                <Col sm={4}>
+                    {this.renderUpdateButton()}
+                </Col>
+                <Col>
+                    <Form.Group>
+                        <Form.Group controlId={"update.branch"}>
+                            <Form.Label>Branch</Form.Label>
+                            <Form.Control as="select" 
+                                value={this.props.currentBranch} 
+                                onChange={(e) => this.setState({...this.state, showBranchChangeModal: true, newBranch: e.target.value})}>
+                                {BRANCHES.map((b, index) => {
+                                    return <option key={index}>{b}</option>
+                                })}
+                            </Form.Control>
+                        </Form.Group>
+                    </Form.Group>
+                </Col>
+            </Row>
+            <Modal show={this.state.showBranchChangeModal} 
+                size="lg" 
+                centered 
+                onHide={() => this.setState({...this.state, showBranchChangeModal: false})}>
+                <Modal.Header className="center">
+                    <Modal.Title>Change branch</Modal.Title>
+                </Modal.Header>
+                <Modal.Body>
+                    <p>
+                        Are you sure you want to change branch? 
+                        This operation can break the software. 
+                        In this case you will need to fix it from the command line or even make a fresh install
+                    </p>
+                    <Row>
+                        <Col className="center">
+                            <IconButton onClick={() => this.setState({...this.state, showBranchChangeModal: false})}>
+                                No, changed my mind
+                            </IconButton>
+                        </Col>
+                        <Col className="center">
+                            <IconButton onClick={() => this.setState({...this.state, showBranchChangeModal: false}, () => {
+                                    softwareChangeBranch(this.state.newBranch);
+                                    this.props.goToHome();
+                                })}>
+                                Yes, I know what I'm doing
+                            </IconButton>
+                        </Col>
+                    </Row>
+                </Modal.Body>
+            </Modal>
+            <Modal show={this.state.showUpdateConfirmModal} 
+                size="lg" 
+                centered 
+                onHide={() => this.setState({...this.state, showUpdateConfirmModal: false})}>
+                <Modal.Header className="center">
+                    <Modal.Title>Confirm update</Modal.Title>
+                </Modal.Header>
+                <Modal.Body>
+                    <p className="p-5 center">
+                        Are you sure you want to update the software now? 
+                        The device will be restarted.
+                        The operation may not be completed succesfully and the software may break.
+                        To fix it you may need to use the command line or make a fresh install.
+                    </p>
+                    <Row>
+                        <Col className="center">
+                            <IconButton onClick={() => this.setState({...this.state, showUpdateConfirmModal: false})}>
+                                No, will do it later
+                            </IconButton>
+                        </Col>
+                        <Col className="center">
+                            <IconButton onClick={() => this.setState({...this.state, showUpdateConfirmModal: false}, () => {
+                                    softwareStartUpdate();
+                                    this.props.goToHome();
+                                })}>
+                                Yes, update
+                            </IconButton>
+                        </Col>
+                    </Row>
+                </Modal.Body>
+            </Modal>
+        </Container>
+    }
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(SoftwareVersion);

--- a/frontend/src/structure/tabs/settings/defaultSettings.js
+++ b/frontend/src/structure/tabs/settings/defaultSettings.js
@@ -262,6 +262,11 @@ const defaultSettings = {
 
 		],
 		available: false
+	},
+	updates: {
+		hash: "",
+		branch: "Master",
+		update_available: false
 	}
 }
 

--- a/frontend/src/structure/tabs/settings/selector.js
+++ b/frontend/src/structure/tabs/settings/selector.js
@@ -16,6 +16,17 @@ const shouldCheckUpdate =   state => {
     else return false;
 };    // check for an update every day once
 
+const isUpToDate =          state => {
+    return state.settings.updates.updates_available;
+}
+
+const getCurrentBranch =    state => {
+    return state.settings.updates.branch;
+}
+
+const getCurrentHash =      state => {
+    return state.settings.updates.hash;
+}
 
 export { 
     getSettings, 
@@ -23,5 +34,8 @@ export {
     getIsFastMode, 
     systemIsLinux, 
     shouldCheckUpdate, 
+    isUpToDate,
+    getCurrentBranch,
+    getCurrentHash,
     showLEDs 
 };

--- a/frontend/src/structure/tabs/settings/selector.js
+++ b/frontend/src/structure/tabs/settings/selector.js
@@ -16,8 +16,8 @@ const shouldCheckUpdate =   state => {
     else return false;
 };    // check for an update every day once
 
-const isUpToDate =          state => {
-    return state.settings.updates.updates_available;
+const updateAvailable =          state => {
+    return state.settings.updates.update_available;
 }
 
 const getCurrentBranch =    state => {
@@ -34,7 +34,7 @@ export {
     getIsFastMode, 
     systemIsLinux, 
     shouldCheckUpdate, 
-    isUpToDate,
+    updateAvailable,
     getCurrentBranch,
     getCurrentHash,
     showLEDs 

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -100,8 +100,8 @@ app.bmanager = ButtonsManager(app)
 # Leds controller initialization
 app.lmanager = LedsController(app)
 
-# Get lates commit short hash to use as a version to refresh cached files
-sw_version = software_updates.get_commit_shash()
+# Updates manager
+app.umanager = software_updates.UpdatesManager()
 
 @app.context_processor
 def override_url_for():
@@ -110,7 +110,7 @@ def override_url_for():
 # Adds a version number to the static url to update the cached files when a new version of the software is loaded
 def versioned_url_for(endpoint, **values):
     if endpoint == 'static':
-        values["version"] = sw_version
+        values["version"] = app.umanager.short_hash
     return url_for(endpoint, **values)
 
 

--- a/server/saves/default_settings.json
+++ b/server/saves/default_settings.json
@@ -226,5 +226,10 @@
         "buttons": [],
         "available_values": [],
         "available": false
+    },
+    "updates": {
+        "hash": "",
+        "branch": "Master",
+        "update_available": false
     }
 }

--- a/server/sockets_interface/socketio_callbacks.py
+++ b/server/sockets_interface/socketio_callbacks.py
@@ -1,6 +1,8 @@
 import json
 import shutil
 import os
+from os.path import dirname
+import platform
 
 from server import socketio, app, db
 
@@ -35,11 +37,20 @@ def updates_check():
 
 @socketio.on("software_run_update")
 def updates_run_update():
-    app.logger.error("TODO: RUN SOFTWARE UPDATE")
+    folder = dirname(dirname(dirname(os.path.realpath(__file__))))              # must get the main folder path to create the hidden file
+    if platform.system() == "Windows":
+        f = open("{}\\run_update.txt".format(folder), "w")
+        f.write(".")
+        f.close()
+        app.semits.show_toast_on_UI("Restart the server to apply the update")
+    else:
+        os.system("touch {}/run_update.txt".format(folder))
+        os.system("sudo reboot now")
 
 @socketio.on("software_change_branch")
 def updates_run_update(branch):
-    app.logger.error("TODO: RUN BRANCH CHANGE {}".format(branch))
+    os.system("git checkout {}".format(branch.lower()))
+    updates_run_update()
 
 # --------------------------------------------------------- PLAYLISTS CALLBACKS -------------------------------------------------------------------------------
 

--- a/server/sockets_interface/socketio_callbacks.py
+++ b/server/sockets_interface/socketio_callbacks.py
@@ -9,20 +9,37 @@ from server.database.models import Playlists
 from server.database.playlist_elements import DrawingElement, GenericPlaylistElement
 from server.database.models import UploadedFiles, Playlists
 
-# request to check if a new version of the software is available 
-@socketio.on('software_updates_check')
-def handle_software_updates_check():
-    result = software_updates.compare_local_remote_tags()
-    if result:
-        if result["behind_remote"]:
-            toast = """A new update is available ({0})\n
-            Your version is {1}\n
-            Check the github page to update to the latest version.
-            """.format(result["remote_latest"], result["local"])
-            socketio.emit("software_updates_response", toast)
 
 
 # TODO split in multiple files?    
+
+
+# --------------------------------------------------------------- UPDATES -------------------------------------------------------------------------------------
+
+# request to check if a new version of the software is available 
+@socketio.on('software_updates_check')
+def updates_check():
+    if software_updates.get_branch_name() == "master":
+        result = software_updates.compare_local_remote_tags()
+        if result:
+            if result["behind_remote"]:
+                toast = """A new update is available ({0})\n
+                Your version is {1}\n
+                Check the settings tab to upgrade the software""".format(result["remote_latest"], result["local"])
+                socketio.emit("software_updates_response", toast)
+    else:
+        if software_updates.get_update_available():
+            toast = """A new update is available\n
+                Check the settings tab to upgrade the software"""
+            socketio.emit("software_updtates_response", toast)
+
+@socketio.on("software_run_update")
+def updates_run_update():
+    app.logger.error("TODO: RUN SOFTWARE UPDATE")
+
+@socketio.on("software_change_branch")
+def updates_run_update(branch):
+    app.logger.error("TODO: RUN BRANCH CHANGE {}".format(branch))
 
 # --------------------------------------------------------- PLAYLISTS CALLBACKS -------------------------------------------------------------------------------
 

--- a/server/sockets_interface/socketio_callbacks.py
+++ b/server/sockets_interface/socketio_callbacks.py
@@ -49,7 +49,7 @@ def updates_run_update():
 
 @socketio.on("software_change_branch")
 def updates_run_update(branch):
-    os.system("git checkout {}".format(branch.lower()))
+    software_updates.switch_to_branch(branch.lower())
     updates_run_update()
 
 # --------------------------------------------------------- PLAYLISTS CALLBACKS -------------------------------------------------------------------------------
@@ -136,6 +136,9 @@ def settings_request():
     settings["leds"]["has_light_sensor"]["value"] =     app.lmanager.has_light_sensor()     or (not os.getenv("DEV_HWLEDS") is None)
     settings["serial"]["port"]["available_values"] =    app.feeder.serial_ports_list()
     settings["serial"]["port"]["available_values"].append("FAKE")
+    settings["updates"]["hash"] =                       app.umanager.short_hash
+    settings["updates"]["branch"] =                     app.umanager.branch
+    settings["updates"]["update_available"] =           app.umanager.update_available
     tmp = []
     labels = [v["label"] for v in settings["buttons"]["available_values"]]
     for b in settings["buttons"]["buttons"]:

--- a/server/utils/software_updates.py
+++ b/server/utils/software_updates.py
@@ -48,7 +48,29 @@ def get_commit_shash():
     result = subprocess.check_output(['git', 'log', '--pretty=format:"%h"', "-n", "1"])
     return result.decode(encoding="UTF-8").replace('"', '')    
 
-if __name__ == "__main__":
-    print(compare_local_remote_tags(verbose=True))
+def get_branch_name():
+    result = subprocess.check_output(['git', 'rev-parse', '--abbrev-ref', "HEAD"])
+    return result.decode(encoding="UTF_8").replace("\n", "")
 
-    print("\n---------------\nShort hash: {}".format(get_commit_shash()))
+def get_update_available():
+    #subprocess.check_output(['git', "remote", "update"])
+    result = subprocess.check_output(['git', "show", "origin/" + get_branch_name()]).decode(encoding="UTF-8")
+    remote_hash = result.split("\n")[0].split(" ")[1]
+    result = subprocess.check_output(["git", "rev-parse", "HEAD"]).decode(encoding="UTF-8")
+    local_hash = result.replace("\n", "")
+    print(remote_hash)
+    print(local_hash)
+    return not (remote_hash == local_hash)
+
+def switch_to_branch(branch):
+    subprocess.check_output(["git", "checkout", "."])       # clearing local files before moving to another branch
+    subprocess.check_output(["git", "checkout", branch])    # moving to the other branch
+
+if __name__ == "__main__":
+    #print(compare_local_remote_tags(verbose=True))
+
+    print("branch name: {}".format(get_branch_name()))
+
+    print("update available: {}".format(get_update_available()))
+
+    print("Short hash: {}".format(get_commit_shash()))

--- a/server/utils/software_updates.py
+++ b/server/utils/software_updates.py
@@ -58,8 +58,6 @@ def get_update_available():
     remote_hash = result.split("\n")[0].split(" ")[1]
     result = subprocess.check_output(["git", "rev-parse", "HEAD"]).decode(encoding="UTF-8")
     local_hash = result.replace("\n", "")
-    print(remote_hash)
-    print(local_hash)
     return not (remote_hash == local_hash)
 
 def switch_to_branch(branch):

--- a/server/utils/software_updates.py
+++ b/server/utils/software_updates.py
@@ -45,12 +45,16 @@ def get_branch_name():
     return result.decode(encoding="UTF_8").replace("\n", "")
 
 def get_update_available():
-    #subprocess.check_output(['git', "remote", "update"])
-    result = subprocess.check_output(['git', "show", "origin/" + get_branch_name()]).decode(encoding="UTF-8")
-    remote_hash = result.split("\n")[0].split(" ")[1]
-    result = subprocess.check_output(["git", "rev-parse", "HEAD"]).decode(encoding="UTF-8")
-    local_hash = result.replace("\n", "")
-    return not (remote_hash == local_hash)
+    try:
+        subprocess.check_output(['git', "remote", "update"])
+        result = subprocess.check_output(['git', "show", "origin/" + get_branch_name()]).decode(encoding="UTF-8")
+        remote_hash = result.split("\n")[0].split(" ")[1]
+        result = subprocess.check_output(["git", "rev-parse", "HEAD"]).decode(encoding="UTF-8")
+        local_hash = result.replace("\n", "")
+        return not (remote_hash == local_hash)
+    except:
+        # usually is a connection error but should make better checks
+        return False
 
 def switch_to_branch(branch):
     subprocess.check_output(["git", "checkout", "."])       # clearing local files before moving to another branch

--- a/server/utils/software_updates.py
+++ b/server/utils/software_updates.py
@@ -4,21 +4,15 @@ from packaging import version
 # Checks if there is a newer version/tag in the remote repo
 # return a dict with remote and local tags plus a "behind" boolean if the remote version is higher
 # return false if cannot compare tags because of a missing network connection
-def compare_local_remote_tags(verbose=False):
+def compare_local_remote_tags():
     result = {}
-    if not verbose:
-        def printv(val):
-            pass
-    else: printv = print
 
     # Requesting remote tags
     try:
         remote_tags = subprocess.check_output(['git', 'ls-remote', '--tags'], stderr=subprocess.STDOUT)
     except:
-        printv("No connection available. Cannot check latest version.")
         return False
     remote_tags = remote_tags.decode(encoding="UTF-8").split("\n")
-    printv("Remote tags: \n{}\n\n".format(remote_tags))
 
     # Cleaning output
     remote_versions = []
@@ -31,12 +25,10 @@ def compare_local_remote_tags(verbose=False):
     remote_versions = [version.parse(t) for t in remote_versions]
     remote_versions = sorted(remote_versions, reverse=True)
     result["remote_latest"] = remote_versions[0]
-    printv("Remote latest version: {}".format(result["remote_latest"]))
     
     # Requesting local tag
     local_tag = subprocess.check_output(['git', 'describe', '--tags', '--abbrev=0'])
     local_tag = version.parse(local_tag.decode(encoding="UTF-8"))
-    printv("Local tag: {}".format(local_tag))
     result["local"] = local_tag
 
     # Comparing outputs
@@ -63,6 +55,16 @@ def get_update_available():
 def switch_to_branch(branch):
     subprocess.check_output(["git", "checkout", "."])       # clearing local files before moving to another branch
     subprocess.check_output(["git", "checkout", branch])    # moving to the other branch
+
+class UpdatesManager():
+    def __init__(self):
+        self.branch = get_branch_name()
+        self.short_hash = get_commit_shash()
+        if self.branch == "master":
+            self.update_available = compare_local_remote_tags()["behind_remote"]
+        else:
+            self.update_available = get_update_available()
+
 
 if __name__ == "__main__":
     #print(compare_local_remote_tags(verbose=True))

--- a/start.py
+++ b/start.py
@@ -140,7 +140,7 @@ if __name__ == "__main__":
             os.system("{}\\install.bat".format(folder))
     else:
         if os.path.isfile("{}/run_update.txt".format(folder)):
-            os.remove("{}\\run_update.txt".format(folder))
+            os.remove("{}/run_update.txt".format(folder))
             os.system("git pull")
             os.system("bash {}/install.sh".format(folder))
 

--- a/start.py
+++ b/start.py
@@ -136,10 +136,12 @@ if __name__ == "__main__":
     if platform.system() == "Windows":
         if os.path.isfile("{}\\run_update.txt".format(folder)):
             os.remove("{}\\run_update.txt".format(folder))
+            os.system("git pull")
             os.system("{}\\install.bat".format(folder))
     else:
         if os.path.isfile("{}/run_update.txt".format(folder)):
             os.remove("{}\\run_update.txt".format(folder))
+            os.system("git pull")
             os.system("bash {}/install.sh".format(folder))
 
     # start the server

--- a/start.py
+++ b/start.py
@@ -131,6 +131,18 @@ def print_help():
 
 if __name__ == "__main__":
     folder = os.path.dirname(os.path.realpath(__file__))
+
+    # check if must update the software before starting
+    if platform.system() == "Windows":
+        if os.path.isfile("{}\\run_update.txt".format(folder)):
+            os.remove("{}\\run_update.txt".format(folder))
+            os.system("{}\\install.bat".format(folder))
+    else:
+        if os.path.isfile("{}/run_update.txt".format(folder)):
+            os.remove("{}\\run_update.txt".format(folder))
+            os.system("bash {}/install.sh".format(folder))
+
+    # start the server
     generate_start_file(folder)                 # generate the .bat or .sh file
 
     try:


### PR DESCRIPTION
With this branch a new setting section is added. 

It brings the version of the software (branch and commit hash), the possibility to change between the master, beta and alpha branches and a button to update without the need of using the ssh terminal.

The feature is basic, just a shortcut to avoid using the ssh but it is not reliable. Will need to add some advanced checks to see if the update has gone wrong, retry or restore to previous versions. Don't want to do it now, it will require a lot of work.

Another solution may be to use docker to manage this things as well (#8)